### PR TITLE
[DNM] Manually initiate September build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,9 @@ workflows:
   main:
     jobs:
       - test
-      - publish-edge:
+      - publish-monthly:
           requires:
             - test
-          filters:
-            branches:
-              only: master
           context: org-global
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
       - image: docker:stable-git
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: "Build Docker Image"
           command: docker build --pull -t cibuilds/base:$CIRCLE_SHA1 .


### PR DESCRIPTION
**Do not merge this PR**

This PR was created to manually run a September release build. This is because the monthly releases are done on cron on the 2nd of the month. This is our first time and we're already in the middle of September.

This branch also allows us to make sure the new CircleCI config release logic works as expected.

If a September release is published to Docker Hub successfully, we can then close this PR.